### PR TITLE
A way to get the current socket instead of a room

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ exports.init = function (compound) {
                 ctl.perform(r.action, {
                     session: hs.session,
                     sessionID: hs.sessionID,
-                    params: data
+                    params: data,
+                    socket: socket
                 }, {}, fn);
             });
         });


### PR DESCRIPTION
When I do `socket().emit(...)` in my controller I fire the same event (with the same data) on all opened sockets because `socket()` function returns the room (because _rw.io_ does `socket.join(...)` and `io.sockets.in(...)`).

What is the best way to do firing only on the current socket?
I added the socket reference into the request object.

```
req.socket.emit(...)
```
